### PR TITLE
Moved RSpec to top level of Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,11 +41,13 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Authentication purposes
 gem 'devise', '~> 4.5.0'
 
+# Heroku probably wants to have rspec in production
+gem 'rspec-rails', '~> 3.8'
+gem 'rspec', '~> 3.8'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails', '~> 3.8'
-  gem 'rspec', '~> 3.8'
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.2'
 end
 


### PR DESCRIPTION
Heroku wants to run RSpec in production as well, even though it doesn't make much sense I think (since we have TravisCI already).