### PR TITLE
Removed redundant routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :caterings
   devise_for :users
   
-  resources :caterings do
+  resources :caterings, only: [:index, :show] do
     resources :meals, only: [:index, :show, :edit]
   end
   root to: "welcome#index"


### PR DESCRIPTION
- `caterings#create`
- `caterings#new`
- `caterings#edit`
- `caterings#update`
- `caterings#destroy`

Only two remain:

- `caterings#index`
- `caterings#show`

The routes are redundant, because caterings are being created by Devise signup paths anyway.